### PR TITLE
Fixed invalid escape sequences

### DIFF
--- a/qc/bwa.py
+++ b/qc/bwa.py
@@ -190,7 +190,7 @@ class Bwa(LogMain):
         """
         Make sure that the file that is being processed is the actual sample
 
-        - ``[main] CMD: bwa mem -p -t 8 -R @RG\tID:HSRR062625\tLB:HSRR062625\tSM:HSRR062625\tPU:unknown\ ...``
+        - ``[main] CMD: bwa mem -p -t 8 -R @RG\tID:HSRR062625\tLB:HSRR062625\tSM:HSRR062625\tPU:unknown ...``
         - If we are processing sample HSRR062625 we should only have this value in this string
         """
         if len(re.findall(self.sample, self.log_file[-2])) == 0:

--- a/qc/samsort.py
+++ b/qc/samsort.py
@@ -97,7 +97,7 @@ class SamSort(LogMain):
         - ``[bam_sort_core] merging from files and in-memory blocks...``
         - We remove the numbers from the string we check since they are variable
         """
-        if re.sub(" \d+", "", self.log_file_2[-1][:-1]) != '[bam_sort_core] merging from files and in-memory blocks...':
+        if re.sub(r" \d+", "", self.log_file_2[-1][:-1]) != '[bam_sort_core] merging from files and in-memory blocks...':
             raise Exception('check_finish_statement: ' + self.sample + ' does not have the final statement we expected')
 
     def check_correct_sample(self):


### PR DESCRIPTION
When importing the scripts via `importlib` a couple of Syntax errors are raised due to invalid escape sequences in the code. This PR fixes both the escapes.

Please consider the use of pre-commit to automatically fix this kind of issues